### PR TITLE
Additions to filter-rspamd.

### DIFF
--- a/filter-rspamd.go
+++ b/filter-rspamd.go
@@ -37,6 +37,7 @@ type session struct {
 	fcrdns string
 	src string
 	dst string
+	mtaName string
 	heloName string
 	userName string
 
@@ -65,6 +66,7 @@ var sessions = make(map[string]session)
 var reporters = map[string]func(string, []string) {
 	"link-connect": linkConnect,
 	"link-disconnect": linkDisconnect,
+	"link-greeting": linkGreeting,
 	"link-identify": linkIdentify,
 	"link-auth": linkAuth,
 	"tx-reset": txReset,
@@ -97,6 +99,16 @@ func linkDisconnect(sessionId string, params []string) {
 		log.Fatal("invalid input, shouldn't happen")
 	}
 	delete(sessions, sessionId)
+}
+
+func linkGreeting(sessionId string, params []string) {
+	if len(params) != 1 {
+		log.Fatal("invalid input, shouldn't happen")
+	}
+
+	s := sessions[sessionId]
+	s.mtaName = params[0]
+	sessions[s.id] = s
 }
 
 func linkIdentify(sessionId string, params []string) {
@@ -256,6 +268,7 @@ func rspamdQuery(s session, token string) {
 		req.Header.Add("Ip", "127.0.0.1")
 	}
 
+	req.Header.Add("MTA-Name", s.mtaName)
 	req.Header.Add("Hostname", s.rdns)
 	req.Header.Add("Helo", s.heloName)
 	req.Header.Add("Queue-Id", s.msgid)

--- a/filter-rspamd.go
+++ b/filter-rspamd.go
@@ -34,9 +34,7 @@ type session struct {
 	id string
 
 	rdns string
-	fcrdns string
 	src string
-	dst string
 	mtaName string
 	heloName string
 	userName string
@@ -92,9 +90,7 @@ func linkConnect(sessionId string, params []string) {
 	s := session{}
 	s.id = sessionId
 	s.rdns = params[0]
-	s.fcrdns = params[1]
 	s.src = params[2]
-	s.dst = params[3]
 	sessions[s.id] = s
 }
 

--- a/filter-rspamd.go
+++ b/filter-rspamd.go
@@ -41,11 +41,11 @@ type session struct {
 	userName string
 
 	msgid string
-	mail_from string
-	rcpt_to []string
+	mailFrom string
+	rcptTo []string
 	message []string
 
-	action string;
+	action string
 }
 
 type rspamd struct {
@@ -124,8 +124,8 @@ func txReset(sessionId string, params []string) {
 
 	s := sessions[sessionId]
 	s.msgid = ""
-	s.mail_from = ""
-	s.rcpt_to = nil
+	s.mailFrom = ""
+	s.rcptTo = nil
 	s.message = nil
 	s.action  = ""
 	s.userName = ""
@@ -152,7 +152,7 @@ func txMail(sessionId string, params []string) {
 	}
 
 	s := sessions[sessionId]
-	s.mail_from = params[1]
+	s.mailFrom = params[1]
 	sessions[s.id] = s
 }
 
@@ -166,7 +166,7 @@ func txRcpt(sessionId string, params []string) {
 	}
 
 	s := sessions[sessionId]
-	s.rcpt_to = append(s.rcpt_to, params[1])
+	s.rcptTo = append(s.rcptTo, params[1])
 	sessions[s.id] = s
 }
 
@@ -195,7 +195,7 @@ func dataCommit(sessionId string, params []string) {
 	s := sessions[sessionId]
 	sessions[sessionId] = s
 
-	
+
 	switch s.action {
 	case "reject":
 		fmt.Printf("filter-result|%s|%s|reject|550 message rejected\n", token, sessionId)
@@ -208,7 +208,6 @@ func dataCommit(sessionId string, params []string) {
 	}
 }
 
-
 func filterInit() {
 	for k := range reporters {
 		fmt.Printf("register|report|smtp-in|%s\n", k)
@@ -216,7 +215,7 @@ func filterInit() {
 	for k := range filters {
 		fmt.Printf("register|filter|smtp-in|%s\n", k)
 	}
-	fmt.Println("register|ready")	
+	fmt.Println("register|ready")
 }
 
 func flushMessage(s session, token string) {
@@ -241,18 +240,18 @@ func rspamdQuery(s session, token string) {
 	} else {
 		req.Header.Add("Ip", "127.0.0.1")
 	}
-	
+
 	req.Header.Add("Hostname", s.rdns)
 	req.Header.Add("Helo", s.heloName)
 	req.Header.Add("Queue-Id", s.msgid)
-	req.Header.Add("From", s.mail_from)
+	req.Header.Add("From", s.mailFrom)
 
 	if s.userName != "" {
 		req.Header.Add("User", s.userName)
 	}
 
-	for _, rcpt_to := range s.rcpt_to {
-		req.Header.Add("Rcpt", rcpt_to)
+	for _, rcptTo := range s.rcptTo {
+		req.Header.Add("Rcpt", rcptTo)
 	}
 
 	resp, err := client.Do(req)
@@ -359,7 +358,7 @@ func main() {
 		if !scanner.Scan() {
 			os.Exit(0)
 		}
-		
+
 		atoms := strings.Split(scanner.Text(), "|")
 		if len(atoms) < 6 {
 			os.Exit(1)

--- a/filter-rspamd.go
+++ b/filter-rspamd.go
@@ -219,17 +219,17 @@ func dataCommit(sessionId string, params []string) {
 
 	switch s.action {
 	case "reject":
-		if( s.response == "") {
+		if( m == "") {
 			m = "message rejected"
 		}
 		fmt.Printf("filter-result|%s|%s|reject|550 %s\n", token, sessionId, m)
 	case "greylist":
-		if( s.response == "") {
+		if( m == "") {
 			m = "try again later"
 		}
 		fmt.Printf("filter-result|%s|%s|reject|421 %s\n", token, sessionId, m)
 	case "soft reject":
-		if( s.response == "") {
+		if( m == "") {
 			m = "try again later"
 		}
 		fmt.Printf("filter-result|%s|%s|reject|451 %s\n", token, sessionId, m)

--- a/filter-rspamd.go
+++ b/filter-rspamd.go
@@ -40,8 +40,8 @@ type session struct {
 	userName string
 
 	msgid string
-	mailFrom string
-	rcptTo []string
+	mail_from string
+	rcpt_to []string
 	message []string
 
 	action string
@@ -140,8 +140,8 @@ func txReset(sessionId string, params []string) {
 
 	s := sessions[sessionId]
 	s.msgid = ""
-	s.mailFrom = ""
-	s.rcptTo = nil
+	s.mail_from = ""
+	s.rcpt_to = nil
 	s.message = nil
 	s.action  = ""
 	sessions[s.id] = s
@@ -167,7 +167,7 @@ func txMail(sessionId string, params []string) {
 	}
 
 	s := sessions[sessionId]
-	s.mailFrom = params[1]
+	s.mail_from = params[1]
 	sessions[s.id] = s
 }
 
@@ -181,7 +181,7 @@ func txRcpt(sessionId string, params []string) {
 	}
 
 	s := sessions[sessionId]
-	s.rcptTo = append(s.rcptTo, params[1])
+	s.rcpt_to = append(s.rcpt_to, params[1])
 	sessions[s.id] = s
 }
 
@@ -282,14 +282,14 @@ func rspamdQuery(s session, token string) {
 	req.Header.Add("Hostname", s.rdns)
 	req.Header.Add("Helo", s.heloName)
 	req.Header.Add("Queue-Id", s.msgid)
-	req.Header.Add("From", s.mailFrom)
+	req.Header.Add("From", s.mail_from)
 
 	if s.userName != "" {
 		req.Header.Add("User", s.userName)
 	}
 
-	for _, rcptTo := range s.rcptTo {
-		req.Header.Add("Rcpt", rcptTo)
+	for _, rcpt_to := range s.rcpt_to {
+		req.Header.Add("Rcpt", rcpt_to)
 	}
 
 	resp, err := client.Do(req)


### PR DESCRIPTION
Hello! Here are some additions for you to consider:

- Process add_headers/remove_headers that rspamd outputs.
- Provide MTA-Name to rspamd now that we can retrieve it from link-greeting.

add_headers come from rspamd in the format of either string or { order: number, value: string }, the latter only for Authentication-Results and with order 1.