### PR TITLE
Align indented X-Spam-Symbols with the rest of the headers.

### DIFF
--- a/filter-rspamd.go
+++ b/filter-rspamd.go
@@ -322,7 +322,7 @@ func rspamdQuery(s *session, token string) {
 				if buf == "" {
 					buf = fmt.Sprintf("%s%s", buf, k)
 				} else {
-					buf = fmt.Sprintf("%s,\n %s", buf, k)
+					buf = fmt.Sprintf("%s,\n\t%s", buf, k)
 				}
 			}
 			writeHeader(s, token, "X-Spam-Symbols", buf)


### PR DESCRIPTION
All the other headers are indented by tabs, so it'll make sense to use tab here as well.