### PR TITLE
Add levels of verbosity to X-Spam-Symbols header pt 2.

### DIFF
--- a/filter-rspamd.go
+++ b/filter-rspamd.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sort"
 
 	"encoding/json"
 	"log"
@@ -64,7 +65,9 @@ type rspamd struct {
 		Remove map[string]int8        `json:"remove_headers"`
 		Add    map[string]interface{} `json:"add_headers"`
 	} `json:"milter"`
-	Symbols map[string]interface{} `json:"symbols"`
+	Symbols map[string]struct{
+		Score   float32
+	} `json:"symbols"`
 }
 
 var sessions = make(map[string]*session)
@@ -315,15 +318,42 @@ func rspamdQuery(s *session, token string) {
 				rr.Score, rr.RequiredScore))
 
 		if len(rr.Symbols) != 0 {
-			buf := ""
-			for k, _ := range rr.Symbols {
-				if buf == "" {
-					buf = fmt.Sprintf("%s%s", buf, k)
-				} else {
-					buf = fmt.Sprintf("%s,\n\t%s", buf, k)
-				}
+			symbols := make([]string, len(rr.Symbols))
+			buf     := &strings.Builder{}
+			i       := 0
+
+			fmt.Printf("filter-dataline|%s|%s|%s: %s, score=%.3f required=%.3f\n",
+				token, s.id, "X-Spam-Status", "Yes", rr.Score, rr.RequiredScore)
+
+			for k := range rr.Symbols {
+				symbols[i] = k
+				i++
 			}
-			writeHeader(s, token, "X-Spam-Symbols", buf)
+	
+			sort.Strings(symbols)
+
+			buf.WriteString("tests=[")
+
+			for i, k := range symbols {
+				sym := fmt.Sprintf("%s=%.3f", k, rr.Symbols[k].Score)
+
+				if buf.Len() > 0 && len(sym) + buf.Len() > 68 {
+					fmt.Printf("filter-dataline|%s|%s|\t%s\n",
+						token, s.id, buf.String())
+					buf.Reset()
+				}
+
+				if buf.Len() > 0 && i > 0 {
+					buf.WriteString(", ")
+				}
+
+				buf.WriteString(sym)
+			}
+
+			fmt.Printf("filter-dataline|%s|%s|\t%s]\n",
+				token, s.id, buf.String())
+
+			buf.Reset()
 		}
 	}
 


### PR DESCRIPTION
Depressing. The branch conflicted and I thought I can recreate the branch from master, but it seems (and makes sense) that it's not possible.

Follow up to:

https://github.com/poolpOrg/filter-rspamd/pull/17

Anyway, I added scores to the brief list and made it wrap at 76 chars.

Default brief mode - wrapped symbol names with scores:

```
X-Spam-Score: 7.266666 / 15
X-Spam-Symbols: TO_MATCH_ENVRCPT_ALL=0.00, FROM_EQ_ENVFROM=0.00
        RCVD_TLS_LAST=0.00, MIME_BAD_ATTACHMENT=1.60, MIME_GOOD=-0.10
        PREVIOUSLY_DELIVERED=0.00, TO_DN_NONE=0.00, MIME_TRACE=0.00
        ARC_NA=0.00, RCVD_VIA_SMTP_AUTH=0.00, FROM_HAS_DN=0.00
        MID_RHS_MATCH_FROM=0.00, BAYES_SPAM=5.10, RCPT_COUNT_ONE=0.00
        DCC_BULK=0.67, RCVD_COUNT_THREE=0.00
```

Full mode - symbol names with score and matched items:
filter "rspamd" proc-exec "filter-rspamd -symbols full"

```
X-Spam-Score: 7.266666 / 15
X-Spam-Symbols: RCPT_COUNT_ONE(0.00)[1]
        DCC_BULK(0.67)[fuz1=many,fuz2=many]
        MIME_TRACE(0.00)[0:+,1:+,2:+,3:~,4:~]
        ARC_NA(0.00)
        TO_MATCH_ENVRCPT_ALL(0.00)
        MIME_BAD_ATTACHMENT(1.60)[jpe]
        MIME_GOOD(-0.10)[multipart/alternative,text/plain,multipart/related]
        RCVD_VIA_SMTP_AUTH(0.00)
        BAYES_SPAM(5.10)[100.00%]
        FROM_EQ_ENVFROM(0.00)
        RCVD_TLS_LAST(0.00)
        MID_RHS_MATCH_FROM(0.00)
        FROM_HAS_DN(0.00)
        PREVIOUSLY_DELIVERED(0.00)[rcpt@host.com]
        RCVD_COUNT_THREE(0.00)[4]
        TO_DN_NONE(0.00)
```