### PR TITLE
Pledge and unveil

### DIFF
--- a/filter-rspamd.go
+++ b/filter-rspamd.go
@@ -27,6 +27,8 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+
+	"github.com/estrogently/puffy"
 )
 
 var rspamdURL *string
@@ -535,6 +537,11 @@ func skipConfig(scanner *bufio.Scanner) {
 func main() {
 	rspamdURL = flag.String("url", "http://localhost:11333", "rspamd base url")
 	flag.Parse()
+
+	puffy.PledgePromises("stdio rpath inet dns unveil")
+	puffy.Unveil("/etc/resolv.conf", "r")
+	puffy.Unveil("/etc/hosts", "r")
+	puffy.UnveilBlock()
 
 	scanner := bufio.NewScanner(os.Stdin)
 

--- a/filter-rspamd.go
+++ b/filter-rspamd.go
@@ -27,8 +27,6 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-
-	"github.com/estrogently/puffy"
 )
 
 var rspamdURL *string
@@ -538,10 +536,10 @@ func main() {
 	rspamdURL = flag.String("url", "http://localhost:11333", "rspamd base url")
 	flag.Parse()
 
-	puffy.PledgePromises("stdio rpath inet dns unveil")
-	puffy.Unveil("/etc/resolv.conf", "r")
-	puffy.Unveil("/etc/hosts", "r")
-	puffy.UnveilBlock()
+	PledgePromises("stdio rpath inet dns unveil")
+	Unveil("/etc/resolv.conf", "r")
+	Unveil("/etc/hosts", "r")
+	UnveilBlock()
 
 	scanner := bufio.NewScanner(os.Stdin)
 

--- a/pledge.go
+++ b/pledge.go
@@ -1,0 +1,15 @@
+// +build !openbsd
+
+package main
+
+func PledgePromises(promises string) error {
+	return nil
+}
+
+func Unveil(path string, flags string) error {
+	return nil
+}
+
+func UnveilBlock() error {
+	return nil
+}

--- a/pledge_openbsd.go
+++ b/pledge_openbsd.go
@@ -1,0 +1,15 @@
+package main
+
+import "golang.org/x/sys/unix"
+
+func PledgePromises(promises string) error {
+	return unix.PledgePromises(promises)
+}
+
+func Unveil(path string, flags string) error {
+	return unix.Unveil(path, flags)
+}
+
+func UnveilBlock() error {
+	return unix.UnveilBlock()
+}


### PR DESCRIPTION
Using [my helper library](https://github.com/estrogently/puffy), which calls the `golang.org/x/sys/unix` functions of the same names on OpenBSD, and does nothing on other platforms.

Currently being used on 6.6-stable with a local rspamd instance without any problems.