### PR TITLE
if url param starts with / use it as unix socket path

### DIFF
--- a/filter-rspamd.go
+++ b/filter-rspamd.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"time"
 	"github.com/tv42/httpunix"
 )
 
@@ -316,10 +315,7 @@ func rspamdTempFail(s *session, token string, log string) {
 func rspamdQuery(s *session, token string) {
 	r := strings.NewReader(strings.Join(s.tx.message, "\n"))
 	t := &http.Transport{}
-	u := &httpunix.Transport{
-		DialTimeout:           100 * time.Millisecond,
-		ResponseHeaderTimeout: 1 * time.Second,
-	}
+	u := &httpunix.Transport{}
 	if len(unixSocketPath) > 0 {
 		u.RegisterLocation("rspamdsocket", unixSocketPath)
 		t.RegisterProtocol(httpunix.Scheme, u)


### PR DESCRIPTION
Allows to connect to rspamd via unix socket, if url param starts with "/" then assume it's path to unix socket, i.e. "-url /var/run/rspamd/rspamd.sock". Uses package https://godoc.org/github.com/tv42/httpunix , tested inside FreeBSD jail, in socket and http mode.