### PR TITLE
Add cmdline option for rspamd Settings-ID HTTP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,5 +62,34 @@ filter "rspamd" proc-exec "filter-rspamd -url http://example.org:11333"
 listen on all filter "rspamd"
 ```
 
+Optionally a `-settings-id` parameter can be used to select a specific rspamd
+setting. One usecase is for example to apply different rspamd rules to incoming
+and outgoing emails:
+
+```
+filter "rspamd-incoming" proc-exec "filter-rspamd"
+filter "rspamd-outgoing" proc-exec "filter-rspamd -settings-id outgoing"
+
+listen on all filter "rspamd-incoming"
+listen on all port submission filter "rspamd-outgoing"
+```
+
+And in `rspamd/local.d/settings.conf`:
+
+```
+outgoing {
+    id = "outgoing";
+    apply {
+        enable_groups = ["dkim"];
+        actions {
+            reject = 100.0;
+            greylist = 100.0;
+            "add header" = 100.0;
+        }
+    }
+}
+```
+
+Every email passed through the `rspamd-outgoing` filter will use the rspamd `outgoing` rule instead of the default rule.
 
 Any configuration with regard to thresholds or enabled modules must be done in rspamd itself.

--- a/filter-rspamd.go
+++ b/filter-rspamd.go
@@ -30,6 +30,7 @@ import (
 )
 
 var rspamdURL *string
+var rspamdSettingsId *string
 var version string
 
 var outputChannel chan string
@@ -338,6 +339,10 @@ func rspamdQuery(s *session, token string) {
 	req.Header.Add("Queue-Id", s.tx.msgid)
 	req.Header.Add("From", s.tx.mailFrom)
 
+	if *rspamdSettingsId != "" {
+		req.Header.Add("Settings-ID", *rspamdSettingsId)
+	}
+
 	if s.userName != "" {
 		req.Header.Add("User", s.userName)
 	}
@@ -552,6 +557,8 @@ func skipConfig(scanner *bufio.Scanner) {
 
 func main() {
 	rspamdURL = flag.String("url", "http://localhost:11333", "rspamd base url")
+	rspamdSettingsId = flag.String("settings-id", "", "rspamd Settings-ID")
+
 	flag.Parse()
 
 	PledgePromises("stdio rpath inet dns unveil")


### PR DESCRIPTION
This allows to distinguish between multiple rspamd settings
by using separate opensmtpd filters with different -settings-id parameters.

For example:

```
dkim {
	id = "dkim";
	apply {
		groups_enabled = ["dkim"];
	}
}
```

```
filter rspamd-dkim proc-exec "opensmtpd-filter-rspamd -url http://localhost:11333 -settings-id dkim"
```