### PR TITLE
Switch to using Go modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The filter currently supports:
 
 
 ## Dependencies
-The filter is written in Golang and doesn't have any dependencies beyond standard library.
+The filter is written in Golang and doesn't have any dependencies beyond the Go extended standard library.
 
 It requires OpenSMTPD 6.6.0 or higher.
 
@@ -30,6 +30,12 @@ $ doas pkg_add opensmtpd-filter-rspamd
 quirks-3.167 signed on 2019-08-11T14:18:58Z
 opensmtpd-filter-rspamd-0.1.x: ok
 $
+```
+
+Install using Go:
+```
+$ GO111MODULE=on go get github.com/poolpOrg/filter-rspamd
+$ doas install -m 0555 ~/go/bin/filter-rspamd /usr/local/libexec/smtpd/filter-rspamd
 ```
 
 Alternatively, clone the repository, build and install the filter:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/poolpOrg/filter-rspamd
+
+go 1.15
+
+require golang.org/x/sys v0.0.0-20200821140526-fda516888d29

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20200821140526-fda516888d29 h1:mNuhGagCf3lDDm5C0376C/sxh6V7fy9WbdEu/YDNA04=
+golang.org/x/sys v0.0.0-20200821140526-fda516888d29/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
- Update statement on dependencies as the sys/unix package is technically from
  the extended library.
- Also add install instructions using Go's built in tooling.

The main motivation behind this PR is to allow filter-rspamd to become independent of the `devel/go-sys` package in OpenBSD's ports tree.

Recently I added the ability to use `portgen` to create Go ports. It simplifies things a bit by allowing us to fetch dependencies automatically (based off the go.mod and go.sum files) - the big advantage here is that we can update individual ports without having to worry about library incompatibilities or intra-dependency-gridlock.

There is one immediate disadvantage to this approach. It relies on Go's handling of version numbers. Anything that is not in the `vX.Y.Z` format (semver) will show up in Go's modules as `v0.0.0-$DATE_OF_LAST_COMMIT-$COMMIT_HASH`. Unfortunately this means we would have to bump `EPOCH` on the filter-rspamd port and switch to a name like `rspamd-$DATE` if we wanted to use the `portgen` approach (`MODGO_MOD*` vars would be used in the ports `Makefile`).

Alternatively, adding a `v` to your git tags moving forward would solve the above problem and allow easy updates in the ports tree.

If this is all entirely too much, I totally understand :D - my main goal is to simplify the Go-OpenBSD-ports ecosystem as much as possible and if this doesn't fit in-line with that, feel free to close with vigor!