### PR TITLE
change linkAuth for the 0.7 protocol version

### DIFF
--- a/filter-rspamd.go
+++ b/filter-rspamd.go
@@ -129,14 +129,24 @@ func linkIdentify(s *session, params []string) {
 }
 
 func linkAuth(s *session, params []string) {
-	if len(params) != 2 {
+	if len(params) < 2 {
 		log.Fatal("invalid input, shouldn't happen")
 	}
-	if params[1] != "pass" {
+
+	var user, res string
+	if version < "0.7" {
+		res = params[len(params) - 1]
+		user = strings.Join(params[0:len(params)-1], "|")
+	} else {
+		res = params[0]
+		user = strings.Join(params[1:], "|")
+	}
+
+	if res != "pass" {
 		return
 	}
 
-	s.userName = params[0]
+	s.userName = user
 }
 
 func txReset(s *session, params []string) {


### PR DESCRIPTION
and while here add an hack to handle users with '|' in their names on previous version of the protocol too.

the 0.7 protocol version is just what I proposed on tech@, so nothing official yet.  see <https://marc.info/?l=openbsd-tech&m=168675334318255&w=2>.

note that the diff linked in the thread has a typo, it should be `params[0:len(params)-1]` not `1:...`, woops :)