### PR TITLE
add X-Spam / X-Spamd /  X-Rspamd headers

### DIFF
--- a/filter-rspamd.go
+++ b/filter-rspamd.go
@@ -515,7 +515,15 @@ func rspamdQuery(s *session, token string) {
 				"ARC-Seal",
 				"ARC-Message-Signature",
 				"ARC-Authentication-Results",
-				"Authentication-Results"}
+				"Authentication-Results",
+				"X-Spam",
+				"X-Spam-Status",
+				"X-Spam-Score",
+				"X-Spam-Level",
+				"X-Spamd-Result",
+				"X-Rspamd-Server",
+				"X-Rspamd-Action",
+			}
 
 			for _, h := range hdrs {
 				if authHeaders[h] != "" {


### PR DESCRIPTION
hello,

when the rspamd `milter_headers` module is configured to add headers to all scanned messages, like this:
```
extended_spam_headers = true;
use = ["add-headers", "x-spam-status", "x-spamd-result", "x-rspamd-server",  "x-rspam-action" ];

```
the `filter-rspamd` filter does not pass on the additional headers to smtpd.


this PR fixes that, alas likely not in the proper way. I have merely extended the `hdrs` literal with the various`X-Spam-*` `X-Spamd-*` and `X-Rspamd-*` headers, hence those get processed the same way as the `ARC-*` headers.


this patch has only been tested on my own systems and might well have some hidden side effects i am not aware of. it does, however, now successfully pipe through all headers added by rspamd to smtpd.

please let me know if you have any concerns with this approach!

thank you for your contributions to the smtpd stack! =)

